### PR TITLE
Diego

### DIFF
--- a/Rates/config_makeCondorJobsData.py
+++ b/Rates/config_makeCondorJobsData.py
@@ -21,7 +21,7 @@ import sys
 #Type True if you want to remake them, False otherwise
 makeInputFilesList = True
 #Directory where your input root files are located
-inputFilesDir = "/eos/cms/store/group/dpg_trigger/comm_trigger/TriggerStudiesGroup/STEAM/dbeghin/CondorTest2"
+inputFilesDir = "/eos/cms/store/group/dpg_trigger/comm_trigger/TriggerStudiesGroup/STEAM/dbeghin/NoCustom"
 
 #Were your input files produced by STEAM? If yes, file_type = "custom"
 #Are these raw data files?
@@ -32,10 +32,10 @@ file_type = "custom"
 #file_type = "L1Accept"
 
 #Directory where the top of your CMSSW release is located
-cmsswDir = "/afs/cern.ch/work/d/dbeghin/Work/Rates/slc7_arch/CMSSW_10_1_9_patch1/src"
+cmsswDir = "/afs/cern.ch/work/d/dbeghin/Work/Rates/2020NewPF/NoCustom/CMSSW_11_1_0_pre4/src"
 
 #Json file
-json_file = "/afs/cern.ch/work/d/dbeghin/Work/Rates/EnvDev/SteamRatesEdmWorkflow/Rates/json_323775.txt"
+json_file = "/afs/cern.ch/work/d/dbeghin/public/json/json_323775.txt"
 
 #Do you wish to use the dataset/group/etc. maps? The maps are unnecessary if you're an HLT developer and you're just testing your new path rate.
 #If you don't want to use any maps, set the variable below to "nomaps"

--- a/Rates/config_mergeOutputsData.py
+++ b/Rates/config_mergeOutputsData.py
@@ -11,25 +11,25 @@ import sys
 --------------------------OPTIONS TO BE FILLED OUT-----------------------------------------
 '''
 #Write the average instant lumi of the json you ran over
-#Units: 10e34 /cm^2/s
-lumi_in = 1.624
+#Units: 1e34 /cm^2/s
+lumi_in = 2.0
 
 #Write the TARGET lumi for which you wish to calculate rates
-#Units: 10e34 /cm^2/s
+#Units: 1e34 /cm^2/s
 lumi_target = 2.0
 
 #Write the HLT prescale used in the json you ran over
 hlt_ps = 1100
 
 #Maps option should be the same one you use to make the batch jobs
-#maps = "nomaps"
-maps = "somemaps"
+maps = "nomaps"
+#maps = "somemaps"
 #maps = "allmaps"
 
 #Do you wish to draw the figures? If you have a slow connection, drawing might take a while
 #This boolean will be set to False if you used the "nomaps" option
-makeFigures = False
-#makeFigures = True
+#makeFigures = False
+makeFigures = True
 
 #Do you wish to take input files from an unusual location (different from the default one)?
 #If you do, set the following boolean to True

--- a/Rates/mergeOutputs.py
+++ b/Rates/mergeOutputs.py
@@ -106,7 +106,7 @@ else:
 print '\n\n\n'
 print 'this is %s' %opts.dataMC
 print 'files_directory = %s' %files_dir
-print 'lumi_target = %s /cm2/s'%opts.lumiTarget
+print 'lumi_target = %se34 /cm2/s'%opts.lumiTarget
 if opts.dataMC == "data":
     print 'lumi_in = %se34 /cm2/s'%opts.lumiIn
     print 'hlt_PS = %s'%opts.hltPS

--- a/Rates/triggerCountsFromTriggerResults.py
+++ b/Rates/triggerCountsFromTriggerResults.py
@@ -488,6 +488,7 @@ for event in events:
 
 nLoop += 1
 outputDir='Jobs'
+if isMC: outputDir += "/" + MCdataset
 
 global_info_file =  open('%s/output.global.%s.csv'%(outputDir,final_string), 'w')
 global_info_file.write("N_LS, " + str(nLS) + "\n")
@@ -497,7 +498,6 @@ global_info_file.close()
     
 #We'll only write the results if there's at least one event
 if atLeastOneEvent:
-    if isMC: outputDir += "/" + MCdataset
 
     misc_path_file = open('%s/output.path.misc.%s.csv'%(outputDir,final_string), 'w')
     misc_path_file.write("Path, Groups, Type, Total Count, Total Rate (Hz), Pure Count, Pure Rate (Hz)\n")

--- a/Rates/triggerCountsFromTriggerResults.py
+++ b/Rates/triggerCountsFromTriggerResults.py
@@ -487,17 +487,18 @@ for event in events:
     nEvents += 1
 
 nLoop += 1
+outputDir='Jobs'
+
+global_info_file =  open('%s/output.global.%s.csv'%(outputDir,final_string), 'w')
+global_info_file.write("N_LS, " + str(nLS) + "\n")
+global_info_file.write("N_eventsInLoop, " + str(nLoop) + "\n")
+global_info_file.write("N_eventsProcessed, " + str(nEvents) + "\n")
+global_info_file.close()
+    
 #We'll only write the results if there's at least one event
 if atLeastOneEvent:
-    outputDir='Jobs'
     if isMC: outputDir += "/" + MCdataset
 
-    global_info_file =  open('%s/output.global.%s.csv'%(outputDir,final_string), 'w')
-    global_info_file.write("N_LS, " + str(nLS) + "\n")
-    global_info_file.write("N_eventsInLoop, " + str(nLoop) + "\n")
-    global_info_file.write("N_eventsProcessed, " + str(nEvents) + "\n")
-    global_info_file.close()
-    
     misc_path_file = open('%s/output.path.misc.%s.csv'%(outputDir,final_string), 'w')
     misc_path_file.write("Path, Groups, Type, Total Count, Total Rate (Hz), Pure Count, Pure Rate (Hz)\n")
     misc_path_file.write("Total Misc, , , " + str(nPassed_Misc) + ", " + str(nPassed_Misc) +"\n")


### PR DESCRIPTION
To save time, output files are not created when no trigger is fired, or when the json rejects all events. However, the global file still needs to be created as it's used for normalizing the rates.

This is a simple fix making sure the global file is always created.