### PR TITLE
allowing condor submission from eos

### DIFF
--- a/Prod/cmsCondorData.py
+++ b/Prod/cmsCondorData.py
@@ -145,7 +145,10 @@ condor_str += '+JobFlavour = "%s"\n'%opts.jobFlavour
 # Adding the requirements line                                                                                                            
 #requirements = "(OpSysAndVer =?= \"CentOS7\")"
 #condor_str += f"requirements = {requirements}\n"
-condor_str += "queue filename matching ("+MYDIR+"/Jobs/Job_*/*.sh)"
+if "/eos/user/" in MYDIR or "/eos/home" in MYDIR:
+    condor_str += "queue filename matching (./Jobs/Job_*/*.sh)"
+else:
+    condor_str += "queue filename matching ("+MYDIR+"/Jobs/Job_*/*.sh)"
 condor_name = MYDIR+"/condor_cluster.sub"
 condor_file = open(condor_name, "w")
 condor_file.write(condor_str)

--- a/Prod/cmsCondorMC.py
+++ b/Prod/cmsCondorMC.py
@@ -210,7 +210,10 @@ condor_str += "output = $Fp(filename)hlt.stdout\n"
 condor_str += "error = $Fp(filename)hlt.stderr\n"
 condor_str += "log = $Fp(filename)hlt.log\n"
 condor_str += '+JobFlavour = "%s"\n'%opts.jobFlavour
-condor_str += "queue filename matching ("+MYDIR+"/Jobs/*/Job_*/*.sh)"
+if "/eos/user/" in MYDIR or "/eos/home" in MYDIR:
+    condor_str += "queue filename matching (./Jobs/*/Job_*/*.sh)"
+else:
+    condor_str += "queue filename matching ("+MYDIR+"/Jobs/*/Job_*/*.sh)"
 condor_name = MYDIR+"/condor_cluster.sub"
 condor_file = open(condor_name, "w")
 condor_file.write(condor_str)

--- a/Rates/condorScriptForRatesData.py
+++ b/Rates/condorScriptForRatesData.py
@@ -115,7 +115,10 @@ condor_str += '+JobFlavour = "%s"\n'%opts.jobFlavour
 # Adding the requirements line                                                                                                            
 #requirements = "(OpSysAndVer =?= \"CentOS7\")"
 #condor_str += f"requirements = {requirements}\n"
-condor_str += "queue filename matching ("+MYDIR+"/Jobs/Job_*/*.sh)"
+if "/eos/user/" in MYDIR or "/eos/home" in MYDIR:
+    condor_str += "queue filename matching (./Jobs/Job_*/*.sh)"
+else:
+    condor_str += "queue filename matching ("+MYDIR+"/Jobs/Job_*/*.sh)"
 condor_name = MYDIR+"/condor_cluster.sub"
 condor_file = open(condor_name, "w")
 condor_file.write(condor_str)

--- a/Rates/condorScriptForRatesMC.py
+++ b/Rates/condorScriptForRatesMC.py
@@ -114,7 +114,10 @@ condor_str += "output = $Fp(filename)counts.stdout\n"
 condor_str += "error = $Fp(filename)counts.stderr\n"
 condor_str += "log = $Fp(filename)counts.log\n"
 condor_str += '+JobFlavour = "%s"\n'%opts.jobFlavour
-condor_str += "queue filename matching ("+MYDIR+"/Jobs/*/Job_*/*.sh)"
+if "/eos/user/" in MYDIR or "/eos/home" in MYDIR:
+    condor_str += "queue filename matching (./Jobs/*/Job_*/*.sh)"
+else:
+    condor_str += "queue filename matching ("+MYDIR+"/Jobs/*/Job_*/*.sh)"
 condor_name = MYDIR+"/condor_cluster.sub"
 condor_file = open(condor_name, "w")
 condor_file.write(condor_str)


### PR DESCRIPTION
Simple fix to allow condor job submission from eos.

This almost, does not change the usual recipe, only requiring  to call:

`module load lxbatch/eossubmit` 

before submitting (some doc can be found [here](https://batchdocs.web.cern.ch/troubleshooting/eos.html#no-eos-submission-allowed))

FYI: @kelmorab @leyva-daina