### PR TITLE
Reduced the size of the Jobs directory

### DIFF
--- a/Prod/cmsCondorData.py
+++ b/Prod/cmsCondorData.py
@@ -29,7 +29,7 @@ help_text += '\n<cfgFileName> (mandatory) = name of your configuration file (e.g
 help_text += '\n<CMSSWrel> (mandatory) = directory where the top of a CMSSW release is located'
 help_text += '\n<remoteDir> (mandatory) = directory where the files will be transfered (e.g. on EOS)'
 help_text += '\n<proxyPath> (optional) = location of your voms cms proxy. Note: keep your proxy in a private directory.'
-help_text += '\n<nPerJob> (optional) = number of files processed per batch job (default=5)'
+help_text += '\n<nPerJob> (optional) = number of files processed per batch job (default=1)'
 help_text += '\n<flavour> (optional) = job flavour (default=workday)\n'
 
 

--- a/Prod/cmsCondorData.py
+++ b/Prod/cmsCondorData.py
@@ -88,6 +88,33 @@ else:
 
 
 
+# create the run_cfg.py 
+
+mainJobDir = MYDIR+'/Jobs'
+os.system('mkdir -p %s'%mainJobDir)
+
+process.source.fileNames = cms.untracked.vstring("INPUTFILES")
+
+tmp_cfgFile = open(mainJobDir+'/run_cfg.py','w')
+tmp_cfgFile.write(process.dumpPython())
+tmp_cfgFile.close()
+
+tmp_cfgFile = open(mainJobDir+'/run_cfg.py','r')
+config_file_lines=list(tmp_cfgFile)
+tmp_cfgFile.close()
+tmp_cfgFile = open(mainJobDir+'/run_cfg.py','w')
+tmp_cfgFile.write("import argparse\n")
+tmp_cfgFile.write("argument_parser = argparse.ArgumentParser()\n")
+tmp_cfgFile.write("argument_parser.add_argument('-i', '--inputFiles', help='Input file name')\n")
+tmp_cfgFile.write("args = argument_parser.parse_args()\n")
+tmp_cfgFile.write("input_file_names = list(args.inputFiles.split(','))\n")
+for line in config_file_lines:
+    if "fileNames = cms.untracked.vstring('INPUTFILES')," in line:
+        line="    fileNames = cms.untracked.vstring(input_file_names),\n"
+    tmp_cfgFile.write(line)
+tmp_cfgFile.close()
+
+
 k=0
 loop_mark = opts.nPerJob
 #make job scripts
@@ -96,6 +123,13 @@ for i in range(0, nJobs):
 
     jobDir = MYDIR+'/Jobs/Job_%s/'%str(i)
     os.system('mkdir -p %s'%jobDir)
+
+    iFileMin = i*opts.nPerJob
+    iFileMax = (i+1)*opts.nPerJob
+
+    file_names  = fullSource.fileNames[iFileMin:iFileMax]
+    file_names = ",".join(file_names)
+    #print(file_names)
 
     tmp_jobname="sub_%s.sh"%(str(i))
     tmp_job=open(jobDir+tmp_jobname,'w')
@@ -112,7 +146,8 @@ for i in range(0, nJobs):
     tmp_job.write("eval `scramv1 runtime -sh`\n")
     tmp_job.write("cd -\n")
     tmp_job.write("cp -f %s* .\n"%(jobDir))
-    tmp_job.write("cmsRun run_cfg.py\n")
+    tmp_job.write("cp -f %s/run_cfg.py .\n"%(mainJobDir))
+    tmp_job.write("cmsRun run_cfg.py --inputFiles=%s \n"%(file_names))
     tmp_job.write("echo 'sending the file back'\n")
     tmp_job.write("cp hlt.root %s/hlt_%s.root\n"%(remoteDir, str(i)))
     tmp_job.write("rm hlt.root\n")
@@ -120,16 +155,6 @@ for i in range(0, nJobs):
     os.system("chmod +x %s"%(jobDir+tmp_jobname))
 
     print ("preparing job number %s/%s"%(str(i), nJobs-1))
-
-    iFileMin = i*opts.nPerJob
-    iFileMax = (i+1)*opts.nPerJob
-          
-    process.source.fileNames = fullSource.fileNames[iFileMin:iFileMax]
-          
-    tmp_cfgFile = open(jobDir+'/run_cfg.py','w')
-    tmp_cfgFile.write(process.dumpPython())
-    tmp_cfgFile.close()
-    
 
 
 condor_str = "executable = $(filename)\n"

--- a/Prod/cmsCondorMC.py
+++ b/Prod/cmsCondorMC.py
@@ -41,7 +41,7 @@ help_text += '\n<cfgFileName> (mandatory) = name of your configuration file (e.g
 help_text += '\n<CMSSWrel> (mandatory) = directory where the top of a CMSSW release is located'
 help_text += '\n<remoteDir> (mandatory) = directory where the files will be transfered (e.g. on EOS)'
 help_text += '\n<proxyPath> (optional) = location of your voms cms proxy. Note: keep your proxy in a private directory.'
-help_text += '\n<nPerJob> (optional) = number of files processed per batch job (default=5)'
+help_text += '\n<nPerJob> (optional) = number of files processed per batch job (default=1)'
 help_text += '\n<flavour> (optional) = job flavour (default=workday)\n'
 
 

--- a/Prod/cmsCondorMC.py
+++ b/Prod/cmsCondorMC.py
@@ -123,6 +123,35 @@ else:
     #print "dataset: ", dataset
     print("(approximate) number of jobs to be created: ", nJobs)
         
+
+
+# create the run_cfg.py 
+
+mainJobDir = MYDIR+'/Jobs'
+os.system('mkdir -p %s'%mainJobDir)
+
+process.source.fileNames = cms.untracked.vstring("INPUTFILES")
+
+tmp_cfgFile = open(mainJobDir+'/run_cfg.py','w')
+tmp_cfgFile.write(process.dumpPython())
+tmp_cfgFile.close()
+
+tmp_cfgFile = open(mainJobDir+'/run_cfg.py','r')
+config_file_lines=list(tmp_cfgFile)
+tmp_cfgFile.close()
+tmp_cfgFile = open(mainJobDir+'/run_cfg.py','w')
+tmp_cfgFile.write("import argparse\n")
+tmp_cfgFile.write("argument_parser = argparse.ArgumentParser()\n")
+tmp_cfgFile.write("argument_parser.add_argument('-i', '--inputFiles', help='Input file name')\n")
+tmp_cfgFile.write("args = argument_parser.parse_args()\n")
+tmp_cfgFile.write("input_file_names = list(args.inputFiles.split(','))\n")
+for line in config_file_lines:
+    if "fileNames = cms.untracked.vstring('INPUTFILES')," in line:
+        line="    fileNames = cms.untracked.vstring(input_file_names),\n"
+    tmp_cfgFile.write(line)
+tmp_cfgFile.close()
+
+
     
 datasetList=[]
 if opts.proxyPath == "noproxy":
@@ -150,31 +179,6 @@ for dataset in datasetList:
     
         jobDir = MYDIR+"/"+datasetJobDir+'/Job_%s/'%str(i)
         os.system('mkdir -p %s'%jobDir)
-    
-        tmp_jobname="sub_%s.sh"%(str(i))
-        tmp_job=open(jobDir+tmp_jobname,'w')
-        tmp_job.write("#!/bin/sh\n")
-        if opts.proxyPath != "noproxy":
-            tmp_job.write("export X509_USER_PROXY=$1\n")
-            tmp_job.write("voms-proxy-info -all\n")
-            tmp_job.write("voms-proxy-info -all -file $1\n")
-        tmp_job.write("ulimit -v 5000000\n")
-        tmp_job.write("cd $TMPDIR\n")
-        tmp_job.write("mkdir Job_%s\n"%str(i))
-        tmp_job.write("cd Job_%s\n"%str(i))
-        tmp_job.write("cd %s\n"%(cmsEnv))
-        tmp_job.write("eval `scramv1 runtime -sh`\n")
-        tmp_job.write("cd -\n")
-        tmp_job.write("cp -f %s* .\n"%(jobDir))
-        tmp_job.write("cmsRun run_cfg.py\n")
-        tmp_job.write("echo 'sending the file back'\n")
-        tmp_job.write("cp hlt.root %s/hlt_%s.root\n"%(datasetRemoteDir, str(i)))
-        tmp_job.write("rm hlt.root\n")
-        tmp_job.close()
-        os.system("chmod +x %s"%(jobDir+tmp_jobname))
-    
-        print("preparing job number %s"%str(jobCount))
-        jobCount += 1
 
         kFileMin = last_kFileMax+i*opts.nPerJob
         kFileMax = last_kFileMax+(i+1)*opts.nPerJob
@@ -191,13 +195,34 @@ for dataset in datasetList:
             keepGoing=False
         if not keepGoing: last_kFileMax = kFileMax
               
-        process.source.fileNames = fullSource.fileNames[kFileMin:kFileMax]
-
-
-        tmp_cfgFile = open(jobDir+'/run_cfg.py','w')
-        tmp_cfgFile.write(process.dumpPython())
-        tmp_cfgFile.close()
+        file_names  = fullSource.fileNames[kFileMin:kFileMax]
+        file_names = ",".join(file_names)
     
+        tmp_jobname="sub_%s.sh"%(str(i))
+        tmp_job=open(jobDir+tmp_jobname,'w')
+        tmp_job.write("#!/bin/sh\n")
+        if opts.proxyPath != "noproxy":
+            tmp_job.write("export X509_USER_PROXY=$1\n")
+            tmp_job.write("voms-proxy-info -all\n")
+            tmp_job.write("voms-proxy-info -all -file $1\n")
+        tmp_job.write("ulimit -v 5000000\n")
+        tmp_job.write("cd $TMPDIR\n")
+        tmp_job.write("mkdir Job_%s\n"%str(i))
+        tmp_job.write("cd Job_%s\n"%str(i))
+        tmp_job.write("cd %s\n"%(cmsEnv))
+        tmp_job.write("eval `scramv1 runtime -sh`\n")
+        tmp_job.write("cd -\n")
+        tmp_job.write("cp -f %s* .\n"%(jobDir))
+        tmp_job.write("cp -f %s/run_cfg.py .\n"%(mainJobDir))
+        tmp_job.write("cmsRun run_cfg.py --inputFiles=%s \n"%(file_names))
+        tmp_job.write("echo 'sending the file back'\n")
+        tmp_job.write("cp hlt.root %s/hlt_%s.root\n"%(datasetRemoteDir, str(i)))
+        tmp_job.write("rm hlt.root\n")
+        tmp_job.close()
+        os.system("chmod +x %s"%(jobDir+tmp_jobname))
+    
+        print("preparing job number %s"%str(jobCount))
+        jobCount += 1
 
 
 condor_str = "executable = $(filename)\n"

--- a/Prod/run_steamflow_cfg.py
+++ b/Prod/run_steamflow_cfg.py
@@ -20,6 +20,9 @@ process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32( nEvents )
 )
 
+# Turn off excessive logging
+process.options.wantSummary = False
+
 def customizeForOfflineProcessing(process):
     # Set ReconnectEachRun and RefreshEachRun to False
     process.GlobalTag.ReconnectEachRun = cms.untracked.bool(False)


### PR DESCRIPTION
Reduced the size of the Jobs directory. For this there are 2 changes:
- Changed the wantSummary parameter to False. This turns off excessive logging and reduces the file size of the stderr log files from 25MB to 2.5MB
- Changed the job submission logic. Before the hlt_config.py, or run_cfg.py as it is called at this stage, was duplicated for each Job with the input files written directly into the respective copies. Since it is about 5MB this required a huge amount of diskspace. Now there is only 1 central run_cfg.py and the input files are provided as arguments. 
Both changes together reduce the size of the Jobs directoy by about 90%.